### PR TITLE
Fixing docs path for Debian build.

### DIFF
--- a/debian/docs
+++ b/debian/docs
@@ -1,1 +1,1 @@
-README
+debian/README

--- a/debian/tpfand.manpages
+++ b/debian/tpfand.manpages
@@ -1,1 +1,1 @@
-tpfand.8
+debian/tpfand.8


### PR DESCRIPTION
This request fixes #1 Ran into this issue while working on my own package :)

Confirmation of the build:

$ ls
debian
$ dpkg-buildpackage -b -uc -uc
---SNIP---
dpkg-deb: building package 'tpfand' in '../tpfand_0.95.3_all.deb'.
 dpkg-genchanges -b >../tpfand_0.95.3_amd64.changes
dpkg-genchanges: binary-only upload (no source code included)
 dpkg-source --after-build tpfancod-packaging
dpkg-buildpackage: binary-only upload (no source included)